### PR TITLE
[server] Fix error where logging of SQL statements was not explicitly disabled

### DIFF
--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -6,7 +6,7 @@ import { defineModels } from "./models";
 
 const url = config.database.url;
 const options: SequelizeOptions = {
-  ...(config.logging.sql && { logging: log_sql }),
+  logging: config.logging.sql && log_sql,
 };
 
 // There is a bug in handling filepaths with spaces when using sqlite via


### PR DESCRIPTION
Logging has to be explicitly disabled, right now there would just be no information passed at all which leads to default logging to the console.